### PR TITLE
Add rules for PHP docs, including params and more.

### DIFF
--- a/WebDevStudios-phpcs/ruleset.xml
+++ b/WebDevStudios-phpcs/ruleset.xml
@@ -16,12 +16,19 @@
   </rule>
 
   <!-- Proper docblocks, thanks to Squiz -->
-  <rule ref="Squiz.Commenting.FunctionComment">
-        <!-- This isn't Java, no need to force function var type-casting -->
-        <exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing"/>
+  <rule ref="Squiz.Commenting.FunctionComment"/>
+
+  <!-- This isn't Java, no need to force function var type-casting -->
+  <rule name="Squiz.Commenting.FunctionComment.TypeHintMissing">
+    <severity>0</severity>
   </rule>
 
   <!-- Doc block alignments -->
   <rule ref="Squiz.Commenting.DocCommentAlignment" />
+
+  <!-- In some cases this isn't possible to catch -->
+  <rule ref="Squiz.PHP.DisallowMultipleAssignments.Found">
+    <severity>0</severity>
+  </rule>
 
 </ruleset>


### PR DESCRIPTION
This now requires doc-blocks to be 100% correct when writing PHP functions, which helps tremendously with documentation down the line.

Previously only IDE's would pick up on this, until I found these while sifting through Squiz's library tonight.

This forces things like the following:
* `@param array $variable This is a full sentence.`
* `@return boolean`

As well as forcing docblock alignments for easier reading. I realize the alignment is subjective, but there's plugins to handle this in most/all editors, but we could definitely scrap this portion if we're not in agreement.