### PR TITLE
Remove Squiz.Commenting.FunctionComme...intMissing

### DIFF
--- a/WebDevStudios-phpcs/ruleset.xml
+++ b/WebDevStudios-phpcs/ruleset.xml
@@ -15,14 +15,6 @@
     <exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
   </rule>
 
-  <!-- Proper docblocks, thanks to Squiz -->
-  <rule ref="Squiz.Commenting.FunctionComment"/>
-
-  <!-- This isn't Java, no need to force function var type-casting -->
-  <rule name="Squiz.Commenting.FunctionComment.TypeHintMissing">
-    <severity>0</severity>
-  </rule>
-
   <!-- Doc block alignments -->
   <rule ref="Squiz.Commenting.DocCommentAlignment" />
 


### PR DESCRIPTION
This removes Squiz.Commenting.FunctionComment.TypeHintMissing issue by removing Squiz.Commenting.FunctionComment all together until a new PR is made to fix it.

https://github.com/WebDevStudios/WDS-Coding-Standards/blob/master/WebDevStudios-phpcs/ruleset.xml#L23

This appears to be failing on Sublime:

![](https://cloudup.com/chlj3Wr_wsU+?r.png)

As you can see, the `Type hint "string" missing for $a` in my status bar. Me and @JayWood both looked into this without any success, so I vote we remove it until a better ruleset can be figured out for anyone using this new standard. 

We should note to check these new rulesets in Store, Sublime, Atom, eg. common editors before we add them in thefuture.