### PR TITLE
Feature: Require @return & Require @since

### DIFF
--- a/WebDevStudios/Sniffs/All/BaseSniff.php
+++ b/WebDevStudios/Sniffs/All/BaseSniff.php
@@ -10,7 +10,7 @@ namespace WebDevStudios\Sniffs\All;
 use PHP_CodeSniffer_Sniff;
 
 /**
- * Base class for extending so you can get common tools.
+ * Base class for extending so you can get the below common tools.
  *
  * @since  1.1
  */

--- a/WebDevStudios/Sniffs/All/BaseSniff.php
+++ b/WebDevStudios/Sniffs/All/BaseSniff.php
@@ -2,8 +2,8 @@
 /**
  * Shared functionality for all sub-classes.
  *
- * @since  1.1
- * @package  WebDevStudios\Sniffs
+ * @since   1.1.0
+ * @package WebDevStudios\Sniffs
  */
 
 namespace WebDevStudios\Sniffs\All;
@@ -12,7 +12,7 @@ use PHP_CodeSniffer_Sniff;
 /**
  * Base class for extending so you can get the below common tools.
  *
- * @since  1.1
+ * @since  1.1.0
  */
 abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
 
@@ -20,37 +20,87 @@ abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
 	 * The tokens.
 	 *
 	 * @author Aubrey Portwood
-	 * @since  1.1
+	 * @since  1.1.0
 	 *
 	 * @var array
 	 */
 	protected $tokens;
 
 	/**
-	 * Record something.
+	 * Push an error to the console.
 	 *
 	 * @author Aubrey Portwood
-	 * @since  1.1
+	 * @since  1.1.0
+	 *
+	 * @param  PHP_CodeSniffer_File $file     The file.
+	 * @param  int                  $where    Where the error happened.
+	 * @param  string               $message  The message.
+	 * @param  int                  $severity The severity, defaults to 0.
+	 */
+	protected function error( &$file, $where, $message, $severity = 0 ) {
+		$this->console( (object) array(
+			'message'  => $message,
+			'start'    => $where,
+			'log'      => 'error',
+			'severity' => $severity,
+		), $file );
+	}
+
+	/**
+	 * Push a warning to the console.
+	 *
+	 * @author Aubrey Portwood
+	 * @since  1.1.0
+	 *
+	 * @param  PHP_CodeSniffer_File $file     The file.
+	 * @param  int                  $where    Where the warning happened.
+	 * @param  string               $message  The message.
+	 * @param  int                  $severity The severity, defaults to 0.
+	 */
+	protected function warn( &$file, $where, $message, $severity = 0 ) {
+		$this->console( (object) array(
+			'message'  => $message,
+			'start'    => $where,
+			'log'      => 'warning',
+			'severity' => $severity,
+		), $file );
+	}
+
+	/**
+	 * Record something to the console.
+	 *
+	 * @author Aubrey Portwood
+	 * @since  1.1.0
 	 *
 	 * @param array                $args {
 	 *     Arguments.
 	 *     @type string $message The message.
 	 *     @type int    $start   The starting position of the record.
-	 *     @type string $error   The simple error message.
-	 *     @type string $metric  The text to record for the metric.
+	 *     @type string $log     Whether to log an `error` or a `warning`.
 	 * }
 	 * @param PHP_CodeSniffer_File $phpcs_file The file.
 	 */
-	protected function record( $args, &$phpcs_file ) {
-		$phpcs_file->addError( $args->message, $args->start, $args->error );
-		$phpcs_file->recordMetric( $args->start, $args->message, $args->metric );
+	private function console( $args, &$phpcs_file ) {
+		$args->log = strtolower( $args->log );
+
+		if ( stristr( $args->log, 'error' ) ) {
+
+			// Log as a error.
+			$phpcs_file->addError( $args->message, $args->start, md5( $args->message ), array(), $args->severity );
+		}
+
+		if ( stristr( $args->log, 'warning' ) ) {
+
+			// Log as an warning.
+			$phpcs_file->addWarning( $args->message, $args->start, md5( $args->message ), array(), $args->severity );
+		}
 	}
 
 	/**
 	 * Get token.
 	 *
 	 * @author Aubrey Portwood
-	 * @since  1.1
+	 * @since  1.1.0
 	 *
 	 * @param int    $position The position of the token.
 	 * @param string $key      The key you want from the array daya, leave empty to get all data.

--- a/WebDevStudios/Sniffs/All/BaseSniff.php
+++ b/WebDevStudios/Sniffs/All/BaseSniff.php
@@ -85,17 +85,20 @@ abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
 	private function console( $args, &$phpcs_file ) {
 		$args->log = strtolower( $args->log );
 
+		// Create a unique error code for this message.
+		$code = sha1( $args->message );
+
 		if ( stristr( $args->log, 'error' ) ) {
 
-			// Log as a error.
-			$phpcs_file->addError( $args->message, $args->start, md5( $args->message ), array(), $args->severity );
+			// Log as an error.
+			$phpcs_file->addError( $args->message, $args->start, $code, array(), $args->severity );
 			return;
 		}
 
 		if ( stristr( $args->log, 'warning' ) ) {
 
-			// Log as an warning.
-			$phpcs_file->addWarning( $args->message, $args->start, md5( $args->message ), array(), $args->severity );
+			// Log as a warning.
+			$phpcs_file->addWarning( $args->message, $args->start, $code, array(), $args->severity );
 			return;
 		}
 	}

--- a/WebDevStudios/Sniffs/All/BaseSniff.php
+++ b/WebDevStudios/Sniffs/All/BaseSniff.php
@@ -79,6 +79,8 @@ abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
 	 *     @type string $log     Whether to log an `error` or a `warning`.
 	 * }
 	 * @param PHP_CodeSniffer_File $phpcs_file The file.
+	 *
+	 * @return void Early bail when we finally log to the console.
 	 */
 	private function console( $args, &$phpcs_file ) {
 		$args->log = strtolower( $args->log );
@@ -87,12 +89,14 @@ abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
 
 			// Log as a error.
 			$phpcs_file->addError( $args->message, $args->start, md5( $args->message ), array(), $args->severity );
+			return;
 		}
 
 		if ( stristr( $args->log, 'warning' ) ) {
 
 			// Log as an warning.
 			$phpcs_file->addWarning( $args->message, $args->start, md5( $args->message ), array(), $args->severity );
+			return;
 		}
 	}
 

--- a/WebDevStudios/Sniffs/All/BaseSniff.php
+++ b/WebDevStudios/Sniffs/All/BaseSniff.php
@@ -6,7 +6,7 @@
  * @package  WebDevStudios\Sniffs
  */
 
-namespace WebDevStudios\Sniffs\Commenting;
+namespace WebDevStudios\Sniffs\All;
 use PHP_CodeSniffer_Sniff;
 
 /**

--- a/WebDevStudios/Sniffs/All/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/All/RequireReturnSniff.php
@@ -86,7 +86,7 @@ class RequireReturnSniff extends BaseSniff {
 			return $this->record( (object) [
 				'message' => 'Please document your return for this function.',
 				'start'   => $doc_block_end,
-				'error'   => 'Missing',
+				'error'   => 'MissingReturnTag',
 				'metric'  => 'yes',
 			], $file );
 		}
@@ -95,7 +95,7 @@ class RequireReturnSniff extends BaseSniff {
 			return $this->record( (object) [
 				'message' => 'Your function does not return anything, no need for @return tag.',
 				'start'   => $doc_block_end,
-				'error'   => 'Missing',
+				'error'   => 'ReturnsNothing',
 				'metric'  => 'yes',
 			], $file );
 		}

--- a/WebDevStudios/Sniffs/All/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/All/RequireReturnSniff.php
@@ -1,6 +1,6 @@
 <?php // @codingStandardsIgnoreLine: Filename is ok.
 
-namespace WebDevStudios\Sniffs\Commenting;
+namespace WebDevStudios\Sniffs\All;
 use PHP_CodeSniffer_Sniff;
 use PHP_CodeSniffer_File;
 

--- a/WebDevStudios/Sniffs/All/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/All/RequireReturnSniff.php
@@ -89,7 +89,7 @@ class RequireReturnSniff extends BaseSniff {
 		}
 
 		if ( ! $have_an_at_return_tag && 'has_return_statement' === $examine_function ) {
-			$this->error( $file, $doc_block_end, 'Please document your return for this function.' );
+			$this->error( $file, $doc_block_end, 'Please document your return for this function in an @return tag.' );
 		}
 
 		if ( $have_an_at_return_tag && 'no_return_statement' === $examine_function ) {

--- a/WebDevStudios/Sniffs/All/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/All/RequireReturnSniff.php
@@ -84,7 +84,7 @@ class RequireReturnSniff extends BaseSniff {
 
 		if ( ! $have_an_at_return_tag && 'has_return_statement' === $examine_function ) {
 			return $this->record( (object) [
-				'message' => 'You have no @return tag, but there is a return statement in your function.',
+				'message' => 'Please document your return for this function.',
 				'start'   => $doc_block_end,
 				'error'   => 'Missing',
 				'metric'  => 'yes',
@@ -93,7 +93,7 @@ class RequireReturnSniff extends BaseSniff {
 
 		if ( $have_an_at_return_tag && 'no_return_statement' === $examine_function ) {
 			return $this->record( (object) [
-				'message' => 'You have an @return tag, but no return statement found.',
+				'message' => 'Your function does not return anything, no need for @return tag.',
 				'start'   => $doc_block_end,
 				'error'   => 'Missing',
 				'metric'  => 'yes',

--- a/WebDevStudios/Sniffs/All/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/All/RequireReturnSniff.php
@@ -1,4 +1,10 @@
 <?php // @codingStandardsIgnoreLine: Filename is ok.
+/**
+ * Require the @return tag.
+ *
+ * @since   1.1.0
+ * @package WebDevStudios\Sniffs
+ */
 
 namespace WebDevStudios\Sniffs\All;
 use PHP_CodeSniffer_Sniff;
@@ -8,7 +14,7 @@ use PHP_CodeSniffer_File;
  * Require the @return tag.
  *
  * @author Aubrey Portwood
- * @since  1.1
+ * @since  1.1.0
  */
 class RequireReturnSniff extends BaseSniff {
 
@@ -16,7 +22,7 @@ class RequireReturnSniff extends BaseSniff {
 	 * What are we parsing?
 	 *
 	 * @author Aubrey Portwood
-	 * @since  1.1
+	 * @since  1.1.0
 	 *
 	 * @var array
 	 */
@@ -29,7 +35,7 @@ class RequireReturnSniff extends BaseSniff {
 	 * Register on all docblock comments.
 	 *
 	 * @author Aubrey Portwood
-	 * @since  1.1
+	 * @since  1.1.0
 	 *
 	 * @return array List of tokens.
 	 */
@@ -49,7 +55,7 @@ class RequireReturnSniff extends BaseSniff {
 	 * Process file.
 	 *
 	 * @author Aubrey Portwood
-	 * @since  1.1
+	 * @since  1.1.0
 	 *
 	 * @param  PHP_CodeSniffer_File $file            The file object.
 	 * @param  int                  $doc_block_start Where the docblock starts.
@@ -83,21 +89,11 @@ class RequireReturnSniff extends BaseSniff {
 		}
 
 		if ( ! $have_an_at_return_tag && 'has_return_statement' === $examine_function ) {
-			return $this->record( (object) [
-				'message' => 'Please document your return for this function.',
-				'start'   => $doc_block_end,
-				'error'   => 'MissingReturnTag',
-				'metric'  => 'yes',
-			], $file );
+			$this->error( $file, $doc_block_end, 'Please document your return for this function.' );
 		}
 
 		if ( $have_an_at_return_tag && 'no_return_statement' === $examine_function ) {
-			return $this->record( (object) [
-				'message' => 'Your function does not return anything, no need for @return tag.',
-				'start'   => $doc_block_end,
-				'error'   => 'ReturnsNothing',
-				'metric'  => 'yes',
-			], $file );
+			$this->error( $file, $doc_block_end, 'Your function does not return anything, no need for @return tag.' );
 		}
 	}
 

--- a/WebDevStudios/Sniffs/Commenting/BaseSniff.php
+++ b/WebDevStudios/Sniffs/Commenting/BaseSniff.php
@@ -1,22 +1,96 @@
-<?php
+<?php // @codingStandardsIgnoreLine: Filename is ok.
+/**
+ * Shared functionality for all sub-classes.
+ *
+ * @since  1.1
+ * @package  WebDevStudios\Sniffs
+ */
 
 namespace WebDevStudios\Sniffs\Commenting;
-
 use PHP_CodeSniffer_Sniff;
 
+/**
+ * Base class for extending so you can get common tools.
+ *
+ * @since  1.1
+ */
 abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * The tokens.
+	 *
+	 * @author Aubrey Portwood
+	 * @since  1.1
+	 *
+	 * @var array
+	 */
 	protected $tokens;
 
+	/**
+	 * Record something.
+	 *
+	 * @author Aubrey Portwood
+	 * @since  1.1
+	 *
+	 * @param array                $args {
+	 *     Arguments.
+	 *     @type string $message The message.
+	 *     @type int    $start   The starting position of the record.
+	 *     @type string $error   The simple error message.
+	 *     @type string $metric  The text to record for the metric.
+	 * }
+	 * @param PHP_CodeSniffer_File $phpcs_file The file.
+	 */
 	protected function record( $args, &$phpcs_file ) {
 		$phpcs_file->addError( $args->message, $args->start, $args->error );
 		$phpcs_file->recordMetric( $args->start, $args->message, $args->metric );
 	}
 
+	/**
+	 * Get token.
+	 *
+	 * @author Aubrey Portwood
+	 * @since  1.1
+	 *
+	 * @param int    $position The position of the token.
+	 * @param string $key      The key you want from the array daya, leave empty to get all data.
+	 *
+	 * @return mixed An array of data if you request all information, any type given the key may be any type in the array.
+	 */
 	protected function get_token( $position, $key = '' ) {
 		if ( ! empty( $key ) ) {
 			return $this->tokens[ $position ][ $key ];
 		}
 
 		return $this->tokens[ $position ];
+	}
+
+	/**
+	 * Wrapper for PHP_CodeSniffer_File->findNext() with validation.
+	 *
+	 * @param PHP_CodeSniffer_File $file The file.
+	 * @param int                  $token      The token position.
+	 * @param string               $token_type The token type for validation.
+	 * @param int                  $start      The position to start searching.
+	 * @param int                  $end        The position to stop searching.
+	 * @param boolean              $trail      Whether to go past $end and search again.
+	 *
+	 * @return boolean|mixed False if the token type did not validate, the value of findNext else.
+	 */
+	protected function find_next( $file, $token, $token_type = null, $start, $end, $trail = false ) {
+
+		// Do findNext.
+		$t = $file->findNext( $token, $start, $end, $trail );
+
+		// Validate it.
+		$valid = $token_type === $this->get_token( $t, 'type' );
+
+		if ( $token_type && ! $valid ) {
+
+			// Not valid.
+			return false;
+		}
+
+		return $t;
 	}
 }

--- a/WebDevStudios/Sniffs/Commenting/BaseSniff.php
+++ b/WebDevStudios/Sniffs/Commenting/BaseSniff.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WebDevStudios\Sniffs\Commenting;
+
+use PHP_CodeSniffer_Sniff;
+
+abstract class BaseSniff implements PHP_CodeSniffer_Sniff {
+	protected $tokens;
+
+	protected function record( $args, &$phpcs_file ) {
+		$phpcs_file->addError( $args->message, $args->start, $args->error );
+		$phpcs_file->recordMetric( $args->start, $args->message, $args->metric );
+	}
+
+	protected function get_token( $position, $key = '' ) {
+		if ( ! empty( $key ) ) {
+			return $this->tokens[ $position ][ $key ];
+		}
+
+		return $this->tokens[ $position ];
+	}
+}

--- a/WebDevStudios/Sniffs/Commenting/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/Commenting/RequireReturnSniff.php
@@ -1,7 +1,6 @@
-<?php
+<?php // @codingStandardsIgnoreLine: Filename is ok.
 
 namespace WebDevStudios\Sniffs\Commenting;
-
 use PHP_CodeSniffer_Sniff;
 use PHP_CodeSniffer_File;
 

--- a/WebDevStudios/Sniffs/Commenting/RequireReturnSniff.php
+++ b/WebDevStudios/Sniffs/Commenting/RequireReturnSniff.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace WebDevStudios\Sniffs\Commenting;
+
+use PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer_File;
+
+class RequireReturnSniff extends BaseSniff {
+	public $supportedTokenizers = [
+		'PHP',
+		// 'JS',
+	];
+
+	public function register() {
+		return [
+
+			/**
+			 * PHP/JS Docblock.
+			 *
+			 * @link http://php.net/manual/en/language.basic-syntax.comments.php
+			 */
+			T_DOC_COMMENT_OPEN_TAG,
+		];
+	}
+
+	public function process( PHP_CodeSniffer_File $file, $doc_block_start ) {
+		$this->tokens = $file->getTokens();
+		$token = $this->tokens[ $doc_block_start ];
+		$doc_block_end = $token['comment_closer'];
+
+		// The @ return in the comment block, false by default.
+		$have_an_at_return_tag = false;
+
+		for ( $i = $doc_block_start; $i <= $doc_block_end; $i++ ) {
+			if ( stristr( $this->tokens[ $i ]['content'], '@return' ) ) {
+
+				// We found an @return in the block.
+				$have_an_at_return_tag = $this->tokens[ $i ];
+			}
+		}
+
+		// If this is a function, does it have a return;? If not, this will come back as true.
+		$examine_return = $this->examine_return( $file, (object) [
+			'doc_block_end' => $doc_block_end,
+		] );
+
+		if ( 'not_a_function' === $examine_return ) {
+
+			// The code after the docblock isn't a function, so this doesn't matter.
+			return;
+		}
+
+		error_log( print_r( array( $examine_return ), true ) );
+
+		if ( ! $have_an_at_return_tag && 'has_return_statement' === $examine_return ) {
+			return $this->record( (object) [
+				'message' => 'You have no @return tag, but there is a return statement in your function.',
+				'start'   => $doc_block_end,
+				'error'   => 'Missing',
+				'metric'  => 'yes',
+			], $file );
+		}
+
+		if ( $have_an_at_return_tag && 'no_return_statement' === $examine_return ) {
+			return $this->record( (object) [
+				'message' => 'You have an @return tag, but no return statement found.',
+				'start'   => $doc_block_end,
+				'error'   => 'Missing',
+				'metric'  => 'yes',
+			], $file );
+		}
+	}
+
+	protected function examine_return( &$file, $args ) {
+
+		// See if we can find a function start.
+		$function_start = $file->findNext( T_FUNCTION, $args->doc_block_end );
+
+		if ( ! $function_start ) {
+
+			// This isn't a function, so we're okay.
+			return 'not_a_function';
+		}
+
+		$doc_block_end_line = $this->get_token( $args->doc_block_end, 'line' );
+		$function_start_line = $this->get_token( $function_start, 'line' );
+
+		if ( $function_start_line !== $doc_block_end_line + 1 ) {
+
+			// This also isn't a function, it's okay.
+			return 'not_a_function';
+		}
+
+		// This is where the function (it's a function) ends...
+		$function_end = $function_start['bracket_closer'];
+
+		// Find a return; statement in the scope.
+		$return = $file->findNext( T_RETURN, $function_start, $function_end, true );
+
+		// Ensure our return is the right type too.
+		$return = ( 'T_RETURN' === $this->get_token( $return, 'type' ) );
+
+		return $return ? 'has_return_statement' : 'no_return_statement';
+	}
+}

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -35,7 +35,7 @@
 
 			./All
 
-		We will then load ./All/BaseSniff.php as a base class.
+		We will first load ./All/BaseSniff.php as a base class.
 		Then we will load ./All/*.php of other rules that extend the BaseSniff class.
 
 		There is no need to add any of the other rules here as long as they

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -26,4 +26,6 @@
 	<rule ref="Squiz.PHP.DisallowMultipleAssignments.Found">
 		<severity>0</severity>
 	</rule>
+
+	<rule ref="WebDevStudios.Commenting.Base" />
 </ruleset>

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -27,5 +27,19 @@
 		<severity>0</severity>
 	</rule>
 
-	<rule ref="WebDevStudios.Commenting.Base" />
+	<!--
+		Load all the rules.
+
+		Since we want all rules to extend the BaseSniff class,
+		we load all rules from one directory:
+
+			./All
+
+		We will then load ./All/BaseSniff.php as a base class.
+		Then we will load ./All/*.php of other rules that extend the BaseSniff class.
+
+		There is no need to add any of the other rules here as long as they
+		extend the BaseSniff class.
+	-->
+	<rule ref="WebDevStudios.All.Base" />
 </ruleset>


### PR DESCRIPTION
A new approach from #4 which just focuses on `@return` and `@since` and it's requirements from scratch. This needs a lot of testing, but seems to be working well in Sublime and Atom. Please load up some of your recent projects and see if `@return` is working as you expect.

Closes #8 and #6 

This _also_ sets up a basic structure for adding new sniffs.