### PR TITLE
extends prettier.io

### DIFF
--- a/WebDevStudios/.eslintrc.js
+++ b/WebDevStudios/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
 	 *
 	 * @@since 1.1
 	 */
-	'extends': 'wordpress',
+	extends: ['wordpress','prettier'],
 
 	/**
 	 * WDS & WordPress Coding Standards for JavaScript.


### PR DESCRIPTION
Ended up doing a bunch of debugging here over on WD_s https://github.com/WebDevStudios/wd_s/pull/364

Ended up, for Prettier, relying on a couple of NPM packages at the project level.

``` javascript
"eslint-config-prettier": "^2.9.0",
"eslint-config-wordpress": "^2.0.0",
"eslint-plugin-prettier": "^2.6.0",
"prettier": "^1.11.1"
```

As well as some workspace settings (in the case of VSCode): 

``` json
"prettier.eslintIntegration": true, // default false
"prettier.stylelintIntegration": true, // default false
```

But as far as WDS coding standards is concerned, we just need to make sure that `.eslintrc.js` extends `prettier`.