### PR TITLE
Update WPCS to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ ___________________
 
 # Changelog
 
+## 1.2
+
+- WordPress Coding Standards update to v1.1.0 #50 #46
+
 ## 1.1.1
 
 - WDSCS now requires WPCS 0.14.1 #34; props @jrfoell

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
     "minimum-stability": "stable",
     "authors": [],
     "require": {
-        "wp-coding-standards/wpcs": "0.14.1"
+        "wp-coding-standards/wpcs": "1.1.0"
     }
 }


### PR DESCRIPTION
Resolves #46 (Will be released with 1.2)

At first look, it appears to work with our standards (nothing broke) and:

PHP_CodeSniffer version 3.2.3 (stable) by Squiz (http://www.squiz.net)
PHP 7.1.17 (cli) (built: Apr 26 2018 22:04:27) ( NTS )

Going to do more testing.

_________

If you're going to review this see https://github.com/WebDevStudios/WDS-Coding-Standards/blob/release-1.2/CONTRIBUTING.md#developing-wdscs or hit me up and I can show you how to use the repo instead for testing.