### PR TITLE
Adds additional directories to the ignore paths list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 *.ini
 WebDevStudios/tests.php
+composer.lock

--- a/WebDevStudios/.sass-lint.yml
+++ b/WebDevStudios/.sass-lint.yml
@@ -17,8 +17,11 @@ files:
    - 'assets/**/_gravity-forms.scss'
    - 'assets/**/_scaffolding.scss'
    - 'assets/**/style.scss'
+   - 'assets/bower_components/**/*.scss'
+   - 'assets/sass/vendor/**/*.scss'
    - 'bourbon-neat/app/**/*.scss'
    - 'bourbon/app/**/*.scss'
+   - 'node_modules/**/*.scss'
    - 'sass/tests/**/*.scss'
    - 'sass/vendor/**/*.scss'
 


### PR DESCRIPTION
When I want to run PHPCS on an entire theme, I'll run this from the theme's root:
```
sass-lint --config /[path-to]/WebDevStudios/.sass-lint.yml '**/*.scss' -v -q -o sasslint-results.txt
```

This will give me a handy `.txt` file of any and all issues in the theme, but also catches files we don't need to check or don't control.

You can manually add ignore paths to this or changing the path you're searching from `**/*.scss` to something like `assets/sass/**/*.scss` but the latter doesn't ignore the theme's `sass/vendor` files unless you specify them directly by file name like we're doing with `_scaffolding` and some others.

But, I figured it might be easier to just add the ignore paths to the `.sass-lint.yml` file instead so we can run `sass-lint` a little more robsutly.

This also works to ignore `assets/sass/vendor/**/*.scss` files if running the command as such:
```
sass-lint --config /[path-to]/WebDevStudios/.sass-lint.yml 'assets/sass/**/*.scss' -v -q -o sasslint-results.txt
```

So, all-around I don't believe this should be a change that anyone "sees" but adds a bit more clarity to some of the ignore rules for different usage cases within the theme.

This update adds the following ignore paths:
- `assets/bower_components/**/*.scss` – this ignores everything inside of `bower_components`
- `assets/sass/vendor/**/*.scss` – we recently moved `normalize.css` and `animate.css` into the theme's file structure to avoid making external calls for these files. This ignores those files.
- `node_modules/**/*.scss` – this ignores everything inside of `node_modules`

I've tested locally and do not see any change in functionality when running `gulp watch` or `gulp` in a theme, with the added benefit of running the above command now ignores the noted files and only returns with errors where they exist in the partials we want to track. I tested adding some bad Sass and incorrect unit usage to some partials and can confirm that the command above did, indeed, return with errors in those files.