### PR TITLE
Allow Class Filenames to Omit class- Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ ___________________
 
 # Changelog
 
+## 1.2.1
+
+- Removes some `class-` prefix and `-template` suffix requirements from filenames.
+
 ## 1.2.0
 
 - WordPress Coding Standards update to `1.2.1`

--- a/WebDevStudios/ruleset.xml
+++ b/WebDevStudios/ruleset.xml
@@ -12,7 +12,7 @@
 		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
 		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
-		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="WordPress.Files.FileName" />
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
 	</rule>
 


### PR DESCRIPTION
Closes #64 

Future work could be done to better sniff class filenames (and other kinds of filenames). But for now, this is a great simple tweak to stop flagging class filenames as discussed in issue #64.