### PR TITLE
Issue/37 add post install commands to composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "authors": [],
     "require": {
         "wp-coding-standards/wpcs": "2.1.0",
-        "squizlabs/php_codesniffer": "3.3.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+        "squizlabs/php_codesniffer": "3.3.1"
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "authors": [],
     "require": {
         "wp-coding-standards/wpcs": "2.1.0",
-        "squizlabs/php_codesniffer": "3.3.1"
+        "squizlabs/php_codesniffer": "3.3.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     }
 }


### PR DESCRIPTION
Closes #37 

This change requires the dealerdirect/phpcodesniffer-composer-installer package as a dev dependency to the WDS Coding Standards. This library was recommended by Composer when installing the WordPress Coding Standards, as it will automatically set the installed_paths value based on any code standards found in the vendor directory.

There may be future considerations when using in a deployment scenario. We'll want to test this change in our deployment environments to see whether those additional considerations are required for us to add as additional scripts within the composer.json file. See https://github.com/dealerdirect/phpcodesniffer-composer-installer for more information.